### PR TITLE
Fixing S1694 Abstract classes should have both abstract and concrete methods

### DIFF
--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/ByteProviderUtil.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/ByteProviderUtil.java
@@ -5,7 +5,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public abstract class ByteProviderUtil {
+public  class ByteProviderUtil {
+
+    private ByteProviderUtil() {}
+
     public static ByteProvider create(final InputStream is) {
         return new ByteProvider() {
             @Override

--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/ByteProviderUtil.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/ByteProviderUtil.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public  class ByteProviderUtil {
+public final class ByteProviderUtil {
 
     private ByteProviderUtil() {}
 

--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
@@ -11,7 +11,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 
-public abstract class IOUtils {
+public class IOUtils {
+
+    private IOUtils() {}
+
     public static String read(InputStream is) throws IOException {
         InputStreamReader reader = null;
         try {

--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
@@ -11,7 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 
-public class IOUtils {
+public final class IOUtils {
 
     private IOUtils() {}
 


### PR DESCRIPTION
Even though the SonarQube gave error for squid:S1118 (Utility classes should not have public constructors), the issue is that of using an abstract class as an utility class. Abstract classes should have both abstract and concrete methods. Your two classes have no abstract methods. They are utility classes. They are not designed to instantiate. They could be made final and also have a private constructor so preventing any object creation.
This PR will remove 60min of TD.
For further info please look at the following link:   
 https://dev.eclipse.org/sonar/rules/show/squid:S1694
 Please let me know if you have any questions.
Fevzi Ozgul