### PR TITLE
Fixing squid: S1166 Exception handlers should preserve the original exception

### DIFF
--- a/app/src/main/java/dubu/github/com/filecacheutilsample/MainActivity.java
+++ b/app/src/main/java/dubu/github/com/filecacheutilsample/MainActivity.java
@@ -9,6 +9,9 @@ import android.view.View;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import dubu.github.com.filecacheutil.FileCache;
 import dubu.github.com.filecacheutil.FileCacheAleadyExistException;
 import dubu.github.com.filecacheutil.FileCacheFactory;
@@ -16,6 +19,8 @@ import dubu.github.com.filecacheutil.FileCacheNotFoundException;
 import dubu.github.com.filecacheutil.FileEntry;
 
 public class MainActivity extends AppCompatActivity {
+
+    private static final Logger LOGGER = Logger.getLogger(MainActivity.class.getName());
 
     private FileCache fileCache;
     private String cacheName = "dubulee";
@@ -48,9 +53,9 @@ public class MainActivity extends AppCompatActivity {
             }
             fileCache = FileCacheFactory.getInstance().get(cacheName);
         } catch (FileCacheAleadyExistException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.INFO,e.getMessage(),e);
         } catch (FileCacheNotFoundException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.INFO,e.getMessage(),e);
         } finally {
         }
 

--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
@@ -10,8 +10,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public final class IOUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(IOUtils.class.getName());
 
     private IOUtils() {}
 
@@ -69,6 +73,7 @@ public final class IOUtils {
             try {
                 stream.close();
             } catch (IOException e) {
+                LOGGER.log(Level.INFO,e.getMessage(),e);
             }
         }
     }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1166- “ Exception handlers should preserve the original exception”. 
This PR will remove 30 min of TD.
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1166
 Please let me know if you have any questions.
Fevzi Ozgul