### PR TITLE
Fixing squid: S1854 Dead stores should be removed

### DIFF
--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
@@ -34,7 +34,7 @@ public final class IOUtils {
     public static void copy(InputStream is, OutputStream out)
             throws IOException {
         byte[] buff = new byte[4096];
-        int len = -1;
+        int len;
         while ((len = is.read(buff)) != -1) {
             out.write(buff, 0, len);
         }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1854 - “ Dead stores should be removed ”. 
This PR will remove 15min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1854
 Please let me know if you have any questions.
Fevzi Ozgul