### PR TITLE
Fixing squid: S1213 the members of an interface declaration or class should appear in a pre defined order

### DIFF
--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/FileCacheFactory.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/FileCacheFactory.java
@@ -9,6 +9,12 @@ public class FileCacheFactory {
     private static boolean initialized = false;
     private static FileCacheFactory instance = new FileCacheFactory();
 
+    private HashMap<String, FileCache> cacheMap = new HashMap<String, FileCache>();
+    private File cacheBaseDir;
+
+    private FileCacheFactory() {
+    }
+
     public static void initialize(Context context) {
         if (!initialized) {
             synchronized (instance) {
@@ -26,12 +32,6 @@ public class FileCacheFactory {
                     "Not initialized. You must call FileCacheFactory.initialize() before getInstance()");
         }
         return instance;
-    }
-
-    private HashMap<String, FileCache> cacheMap = new HashMap<String, FileCache>();
-    private File cacheBaseDir;
-
-    private FileCacheFactory() {
     }
 
     private void init(Context context) {

--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/IOUtils.java
@@ -34,7 +34,7 @@ public final class IOUtils {
     public static void copy(InputStream is, OutputStream out)
             throws IOException {
         byte[] buff = new byte[4096];
-        int len = -1;
+        int len;
         while ((len = is.read(buff)) != -1) {
             out.write(buff, 0, len);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order ”.  This PR will remove 15min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul