### PR TITLE
Fixing squid: S00112 Generic exceptions should never be thrown

### DIFF
--- a/app/src/test/java/dubu/github/com/filecacheutilsample/CustomException.java
+++ b/app/src/test/java/dubu/github/com/filecacheutilsample/CustomException.java
@@ -1,0 +1,31 @@
+package dubu.github.com.filecacheutilsample;
+
+/**
+ * Created by teknopc on 27-Jun-16.
+ */
+public class CustomException extends Exception
+{
+
+    private static final long serialVersionUID = 1997753363232807009L;
+
+    public CustomException()
+    {
+    }
+
+    public CustomException(String message)
+    {
+        super(message);
+    }
+
+    public CustomException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public CustomException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+
+}

--- a/app/src/test/java/dubu/github/com/filecacheutilsample/ExampleUnitTest.java
+++ b/app/src/test/java/dubu/github/com/filecacheutilsample/ExampleUnitTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
  */
 public class ExampleUnitTest {
     @Test
-    public void addition_isCorrect() throws Exception {
+    public void addition_isCorrect() throws CustomException {
         assertEquals(4, 2 + 2);
     }
 }

--- a/filecacheutil/src/main/java/dubu/github/com/filecacheutil/CustomException.java
+++ b/filecacheutil/src/main/java/dubu/github/com/filecacheutil/CustomException.java
@@ -1,0 +1,31 @@
+package dubu.github.com.filecacheutil;
+
+/**
+ * Created by teknopc on 27-Jun-16.
+ */
+public class CustomException extends Exception
+{
+
+    private static final long serialVersionUID = 1997753363232807009L;
+
+    public CustomException()
+    {
+    }
+
+    public CustomException(String message)
+    {
+        super(message);
+    }
+
+    public CustomException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public CustomException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+
+}

--- a/filecacheutil/src/test/java/dubu/github/com/filecacheutil/ExampleUnitTest.java
+++ b/filecacheutil/src/test/java/dubu/github/com/filecacheutil/ExampleUnitTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
  */
 public class ExampleUnitTest {
     @Test
-    public void addition_isCorrect() throws Exception {
+    public void addition_isCorrect() throws CustomException {
         assertEquals(4, 2 + 2);
     }
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00112 - “Generic exceptions should never be thrown”.
This PR will remove 40min of TD. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00112
 Please let me know if you have any questions.
 Fevzi Ozgul